### PR TITLE
[codex] Implement export command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added `imgflare export` for writing image migration data to JSON or CSV files.
+- Implemented `imgflare export` JSON/CSV migration handoff output with status filtering and file path options.
 
 ## [1.3.0] - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `imgflare export` for writing image migration data to JSON or CSV files.
+
 ## [1.3.0] - 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -187,7 +187,15 @@ imgflare stats
 ```bash
 imgflare export json
 imgflare export csv
+imgflare export csv --file ./migration-map.csv
+imgflare export json --status complete
 ```
+
+Exports include image IDs, original URLs, Cloudflare URLs, status, metadata, timestamps, errors, and variant data. If no `--file` is provided, ImgFlare writes to `imgflare-export-YYYY-MM-DD.<format>` in the current directory.
+
+Options:
+- `--file <file>` or `-f <file>`: Output file path
+- `--status <status>` or `-s <status>`: Filter by status
 
 ## Security
 

--- a/lib/commands/export.js
+++ b/lib/commands/export.js
@@ -17,6 +17,7 @@ const EXPORT_COLUMNS = [
   'error',
   'variants'
 ];
+const ALLOWED_STATUSES = ['pending', 'complete', 'failed'];
 
 /**
  * Register the export command
@@ -43,12 +44,14 @@ async function exportImages(format, options = {}) {
   // Check if tool is configured
   if (!(await isConfigured())) {
     console.error(chalk.red('❌ ImgFlare is not configured. Run "imgflare setup" first.'));
+    process.exitCode = 1;
     return;
   }
   
   // Validate format
   if (format !== 'json' && format !== 'csv') {
     console.error(chalk.red('❌ Invalid format. Use "json" or "csv".'));
+    process.exitCode = 1;
     return;
   }
   
@@ -56,6 +59,12 @@ async function exportImages(format, options = {}) {
     console.log(chalk.blue(`📤 Exporting image data as ${format.toUpperCase()}`));
     const filters = {};
     if (options.status) {
+      if (!ALLOWED_STATUSES.includes(options.status)) {
+        console.error(chalk.red('❌ Invalid status. Use "pending", "complete", or "failed".'));
+        process.exitCode = 1;
+        return;
+      }
+
       filters.status = options.status;
     }
 
@@ -96,7 +105,11 @@ function normalizeValue(value) {
 }
 
 function escapeCsvValue(value) {
-  const normalized = normalizeValue(value);
+  let normalized = normalizeValue(value);
+  if (/^[=+\-@]/.test(normalized)) {
+    normalized = `'${normalized}`;
+  }
+
   if (/[",\n\r]/.test(normalized)) {
     return `"${normalized.replace(/"/g, '""')}"`;
   }

--- a/lib/commands/export.js
+++ b/lib/commands/export.js
@@ -2,6 +2,21 @@ import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import { isConfigured } from '../config.js';
+import { getImages } from '../database.js';
+
+const EXPORT_COLUMNS = [
+  'id',
+  'original_url',
+  'cloudflare_url',
+  'status',
+  'size',
+  'width',
+  'height',
+  'content_type',
+  'uploaded_at',
+  'error',
+  'variants'
+];
 
 /**
  * Register the export command
@@ -39,9 +54,67 @@ async function exportImages(format, options = {}) {
   
   try {
     console.log(chalk.blue(`📤 Exporting image data as ${format.toUpperCase()}`));
-    console.log(chalk.yellow('Export functionality will be implemented in a future update.'));
+    const filters = {};
+    if (options.status) {
+      filters.status = options.status;
+    }
+
+    const images = await getImages(filters);
+    const outputFile = options.file || getDefaultExportFile(format);
+    const outputPath = path.resolve(outputFile);
+    const outputDir = path.dirname(outputPath);
+
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    const contents = format === 'json'
+      ? formatJson(images)
+      : formatCsv(images);
+
+    fs.writeFileSync(outputPath, contents, 'utf8');
+
+    console.log(chalk.green(`✅ Exported ${images.length} images to ${outputPath}`));
     
   } catch (error) {
     console.error(chalk.red(`\n❌ Error exporting images: ${error.message}`));
+    process.exitCode = 1;
   }
+}
+
+function getDefaultExportFile(format) {
+  const date = new Date().toISOString().slice(0, 10);
+  return `imgflare-export-${date}.${format}`;
+}
+
+function normalizeValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  return String(value);
+}
+
+function escapeCsvValue(value) {
+  const normalized = normalizeValue(value);
+  if (/[",\n\r]/.test(normalized)) {
+    return `"${normalized.replace(/"/g, '""')}"`;
+  }
+
+  return normalized;
+}
+
+function formatCsv(images) {
+  const header = EXPORT_COLUMNS.join(',');
+  const rows = images.map(image => {
+    return EXPORT_COLUMNS
+      .map(column => escapeCsvValue(image[column]))
+      .join(',');
+  });
+
+  return [header, ...rows].join('\n') + '\n';
+}
+
+function formatJson(images) {
+  return JSON.stringify(images, null, 2) + '\n';
 }

--- a/lib/commands/export.js
+++ b/lib/commands/export.js
@@ -81,7 +81,7 @@ async function exportImages(format, options = {}) {
       ? formatJson(images)
       : formatCsv(images);
 
-    fs.writeFileSync(outputPath, contents, 'utf8');
+    await fs.promises.writeFile(outputPath, contents, 'utf8');
 
     console.log(chalk.green(`✅ Exported ${images.length} images to ${outputPath}`));
     


### PR DESCRIPTION
## Summary
- Implement imgflare export for JSON and CSV migration handoff files.
- Add default disk output naming when --file is omitted.
- Support status-filtered exports and document export options.

## Validation
- npm run lint passes with existing unrelated warnings.
- npm run build passes.
- git diff --check passes.
- node bin/imgflare.js export json --file /private/tmp/imgflare-export-test.json exported 24 images.
- node bin/imgflare.js export csv --file /private/tmp/imgflare-export-test.csv --status complete exported 23 images.
- Parsed the generated JSON and checked the CSV header/output shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an export command to write image migration data in JSON or CSV. Supports filtering by status, custom output file paths, and sensible default filenames when no file is specified. Exports include image IDs, original/Cloudflare URLs, status, metadata, timestamps, variant data, and error details.

* **Documentation**
  * README updated with usage examples and detailed option/output descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Heartbred-Media/ImgFlare/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->